### PR TITLE
Created a new TableViewCell for Date Picker

### DIFF
--- a/Bohr.xcodeproj/project.pbxproj
+++ b/Bohr.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		287EC9361B4BA799002E2110 /* BODateTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 287EC9341B4BA799002E2110 /* BODateTableViewCell.h */; };
+		287EC9371B4BA799002E2110 /* BODateTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 287EC9351B4BA799002E2110 /* BODateTableViewCell.m */; };
 		754E56501B1B461700075B6E /* BOTableViewCell+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 754E564F1B1B461700075B6E /* BOTableViewCell+Subclass.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		754E56891B1DFDB400075B6E /* BOSetting.h in Headers */ = {isa = PBXBuildFile; fileRef = 754E56871B1DFDB400075B6E /* BOSetting.h */; };
 		754E568A1B1DFDB400075B6E /* BOSetting.m in Sources */ = {isa = PBXBuildFile; fileRef = 754E56881B1DFDB400075B6E /* BOSetting.m */; };
@@ -64,6 +66,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		287EC9341B4BA799002E2110 /* BODateTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BODateTableViewCell.h; sourceTree = "<group>"; };
+		287EC9351B4BA799002E2110 /* BODateTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BODateTableViewCell.m; sourceTree = "<group>"; };
 		754E564F1B1B461700075B6E /* BOTableViewCell+Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BOTableViewCell+Subclass.h"; sourceTree = "<group>"; };
 		754E56871B1DFDB400075B6E /* BOSetting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOSetting.h; sourceTree = "<group>"; };
 		754E56881B1DFDB400075B6E /* BOSetting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOSetting.m; sourceTree = "<group>"; };
@@ -176,6 +180,8 @@
 				75E02FE11B21F72C009698D3 /* BOTextTableViewCell.h */,
 				75E02FE21B21F72C009698D3 /* BOTextTableViewCell.m */,
 				754E56931B2083DE00075B6E /* BOTimeTableViewCell.h */,
+				287EC9341B4BA799002E2110 /* BODateTableViewCell.h */,
+				287EC9351B4BA799002E2110 /* BODateTableViewCell.m */,
 				754E56941B2083DE00075B6E /* BOTimeTableViewCell.m */,
 				754E56A21B20D2FE00075B6E /* BOChoiceTableViewCell.h */,
 				754E56A31B20D2FE00075B6E /* BOChoiceTableViewCell.m */,
@@ -217,6 +223,7 @@
 				75B6CE1C1B3756D800DADCBD /* BOOptionTableViewCell.h in Headers */,
 				75C7AE291B1AB42A0050C8AA /* BOTableViewCell.h in Headers */,
 				759E1B001B2BC31700AD8F38 /* BOTimeTableViewCell.h in Headers */,
+				287EC9361B4BA799002E2110 /* BODateTableViewCell.h in Headers */,
 				75B6CE1E1B375DCA00DADCBD /* BOButtonTableViewCell.h in Headers */,
 				D5F1D8A91B3A1EF1004DA018 /* BOTableViewController+Private.h in Headers */,
 			);
@@ -342,6 +349,7 @@
 				759E1B011B2BC31700AD8F38 /* BOTimeTableViewCell.m in Sources */,
 				75B6CE1D1B3756D800DADCBD /* BOOptionTableViewCell.m in Sources */,
 				75E19B471B2BCCFE00C03FF6 /* BOTextTableViewCell.m in Sources */,
+				287EC9371B4BA799002E2110 /* BODateTableViewCell.m in Sources */,
 				75E19B451B2BC76100C03FF6 /* BOChoiceTableViewCell.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bohr/BODateTableViewCell.h
+++ b/Bohr/BODateTableViewCell.h
@@ -1,0 +1,18 @@
+//
+//  BODateTableViewCell.h
+//  Bohr
+//
+//  Created by Amit Prabhu on 07/07/15.
+//
+//
+
+#import "BOTableViewCell.h"
+
+@interface BODateTableViewCell : BOTableViewCell
+
+/// The minimum date to be showed on the date picker view.
+//@property (nonatomic) IBInspectable NSString *minimumDate;
+/// The maximum date to be showed on the date picker view.
+//@property (nonatomic) IBInspectable NSString *maximumDate;
+
+@end

--- a/Bohr/BODateTableViewCell.h
+++ b/Bohr/BODateTableViewCell.h
@@ -10,9 +10,7 @@
 
 @interface BODateTableViewCell : BOTableViewCell
 
-/// The minimum date to be showed on the date picker view.
-//@property (nonatomic) IBInspectable NSString *minimumDate;
-/// The maximum date to be showed on the date picker view.
-//@property (nonatomic) IBInspectable NSString *maximumDate;
+// Date DIsplay Format
+@property (nonatomic) IBInspectable NSString *dateFormat;
 
 @end

--- a/Bohr/BODateTableViewCell.m
+++ b/Bohr/BODateTableViewCell.m
@@ -1,0 +1,61 @@
+//
+//  BODateTableViewCell.m
+//  Bohr
+//
+//  Created by Amit Prabhu on 07/07/15.
+//
+//
+
+#import "BODateTableViewCell.h"
+
+#import "BOTableViewCell+Subclass.h"
+
+@interface BODateTableViewCell ()
+
+@property (nonatomic, strong) UIDatePicker *datePicker;
+@property (nonatomic, strong) NSDateFormatter *dateFormatter;
+
+@end
+
+@implementation BODateTableViewCell
+
+- (void)setup {
+    
+    // Setup DatePicker
+    self.datePicker = [UIDatePicker new];
+    self.datePicker.backgroundColor = [UIColor clearColor];
+    [self.contentView addSubview:self.datePicker];
+    [self.datePicker setDatePickerMode:UIDatePickerModeDate];
+    [self.datePicker addTarget:self action:@selector(onDatePickerValueChanged:) forControlEvents:UIControlEventValueChanged];
+    
+    NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:self.datePicker attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.datePicker.superview attribute:NSLayoutAttributeTopMargin multiplier:1 constant:0];
+    NSLayoutConstraint *leftConstraint = [NSLayoutConstraint constraintWithItem:self.datePicker attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self.datePicker.superview attribute:NSLayoutAttributeLeft multiplier:1 constant:0];
+    NSLayoutConstraint *rightConstraint = [NSLayoutConstraint constraintWithItem:self.datePicker attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self.datePicker.superview attribute:NSLayoutAttributeRight multiplier:1 constant:0];
+    NSLayoutConstraint *heightConstraint = [NSLayoutConstraint constraintWithItem:self.datePicker attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1 constant:216];
+    
+    self.datePicker.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.datePicker.superview addConstraints:@[topConstraint, leftConstraint, rightConstraint, heightConstraint]];
+    
+    // Date formatter settings
+    self.dateFormatter = [NSDateFormatter new];
+    self.dateFormatter.timeZone = [NSTimeZone systemTimeZone];
+    [self.dateFormatter setDateFormat:@"dd MMM yyyy"];
+    
+}
+
+
+- (CGFloat)expansionHeight {
+    return self.datePicker.frame.size.height;
+}
+
+- (void)settingValueDidChange {
+    self.detailTextLabel.text = [self.dateFormatter stringFromDate:self.datePicker.date];
+}
+
+-(void)onDatePickerValueChanged:(UIDatePicker *)datePicker
+{
+    self.detailTextLabel.text = [self.dateFormatter stringFromDate:datePicker.date];
+}
+
+@end
+

--- a/Bohr/BODateTableViewCell.m
+++ b/Bohr/BODateTableViewCell.m
@@ -39,7 +39,8 @@
     // Date formatter settings
     self.dateFormatter = [NSDateFormatter new];
     self.dateFormatter.timeZone = [NSTimeZone systemTimeZone];
-    [self.dateFormatter setDateFormat:@"dd MMM yyyy"];
+    NSString *dateFormatt = self.dateFormat.length==0 ? @"dd MMM YYYY" : self.dateFormat;
+    [self.dateFormatter setDateFormat:dateFormatt];
     
 }
 

--- a/BohrDemo/Main.storyboard
+++ b/BohrDemo/Main.storyboard
@@ -190,7 +190,7 @@
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="GGk-0w-Ubv" id="GWC-7p-ljY">
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Choice disclosure" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4Dt-8J-xwS">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Date Picker" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4Dt-8J-xwS">
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -206,6 +206,7 @@
                                         </tableViewCellContentView>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="string" keyPath="key" value="date"/>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="dateFormat" value="dd-MMM-YYYY"/>
                                         </userDefinedRuntimeAttributes>
                                     </tableViewCell>
                                 </cells>

--- a/BohrDemo/Main.storyboard
+++ b/BohrDemo/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="15A178w" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="lfY-dd-H2u">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="lfY-dd-H2u">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
@@ -183,6 +183,30 @@
                                         <connections>
                                             <segue destination="mPI-tq-cz0" kind="show" id="b7k-4G-YMD"/>
                                         </connections>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="4Dt-8J-xwS" detailTextLabel="wC3-VX-qYR" style="IBUITableViewCellStyleValue1" id="GGk-0w-Ubv" customClass="BODateTableViewCell">
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="GGk-0w-Ubv" id="GWC-7p-ljY">
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Choice disclosure" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4Dt-8J-xwS">
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wC3-VX-qYR">
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="key" value="date"/>
+                                        </userDefinedRuntimeAttributes>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>


### PR DESCRIPTION
Settings Page for most applications contains a field to enter a Birth Date or something similar so a `DatePicker` becomes essential in that case. The `PickerView` won't satisfy their needs hence my fork.

It has a date Format to display in date in the given format into the `detailText` label as an `IBInspectable` with a default fallthorugh to prevent any errors.

All of the contraints implemented from the `BOTimeTableViewCell`.
