### PR TITLE
OptionTableViewCell : allow specific values so the cell's index is not used

### DIFF
--- a/Bohr/BOOptionTableViewCell.h
+++ b/Bohr/BOOptionTableViewCell.h
@@ -13,4 +13,7 @@
 /// The string for the footer title when the cell has a checkmark on it.
 @property (nonatomic) NSString *footerTitle;
 
+/// Setting value when this cell gets selected - cell's row index by default
+@property (nonatomic) NSInteger value;
+
 @end

--- a/Bohr/BOOptionTableViewCell.m
+++ b/Bohr/BOOptionTableViewCell.m
@@ -12,17 +12,28 @@
 
 @implementation BOOptionTableViewCell
 
+@synthesize value = _value;
+
 - (void)setup {
+    self.value = NSIntegerMin;
 	self.selectionStyle = UITableViewCellSelectionStyleDefault;
 }
 
+- (void)setValue:(NSInteger)value {
+    _value = value;
+}
+
+- (NSInteger)value {
+    return _value != NSIntegerMin ? _value : self.indexPath.row;
+}
+
 - (void)wasSelectedFromViewController:(BOTableViewController *)viewController {
-	self.setting.value = @(self.indexPath.row);
+    self.setting.value = @(self.value);
 }
 
 - (void)settingValueDidChange {
-	NSInteger optionIndex = [self.setting.value integerValue];
-	self.accessoryType = (optionIndex == self.indexPath.row) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    BOOL isSelected = [self.setting.value integerValue] == self.value;
+	self.accessoryType = isSelected ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ There's a bunch of built-in `BOTableViewCell` subclasses ready to be used:
 - `BODateTableViewCell`: manages `NSDate` values representing a certain date. A revealing `UIDatePicker` is used to set the time.
 - `BOTimeTableViewCell`: manages `NSDate` values representing a certain time. A revealing `UIDatePicker` is used to set the time.
 - `BOChoiceTableViewCell`: manages `NSInteger` values (which you can understand as "options" from a `NS_ENUM`) through taps on the cell itself.
-- `BOOptionTableViewCell`: manages a single `NSInteger` value (which you can understand as an "option" from a `NS_ENUM`) depending on its position in its table view section. When selected, a checkmark appears on the right side.
+- `BOOptionTableViewCell`: manages a single `NSInteger` value (which you can understand as an "option" from a `NS_ENUM`), by default depending on its position in its table view section but the setting value can be overridden. When selected, a checkmark appears on the right side.
 - `BOButtonTableViewCell`: allows the user to perform an action when the cell is tapped.
 - `BOStepperTableViewCell`: allows the user to change numeric values by tapping on a +- control.
 


### PR DESCRIPTION
The current implementation of optionTableCell uses the cell's index as the setting value when it is selected.

This makes it problematic to change the order of appearance of the settings as their indexes is used as the value and therefore the new cell at that index will be selected in the next release of the application.

I suggest allowing the app to specify a string value for each option that can be used as the setting value when it is selected.

Example:

```
[self.boTableViewController addSection:[BOTableViewSection sectionWithHeaderTitle:@"favorite color" handler:^(BOTableViewSection *section) {
    [section addCell:[BOOptionTableViewCell cellWithTitle:@"Orange" key:@"favcolor" handler:^(BOOptionTableViewCell *cell) {
        cell.value = @"orange";
    }]];
    [section addCell:[BOOptionTableViewCell cellWithTitle:@"Red" key:@"favcolor" handler:^(BOOptionTableViewCell *cell) {
        cell.value = @"red";
    }]];
}]];
```
