### PR TITLE
Cells highlighted colors

### DIFF
--- a/Bohr/BOTableViewCell.h
+++ b/Bohr/BOTableViewCell.h
@@ -20,11 +20,17 @@
 /// The main text font for the cell.
 @property (nonatomic) UIFont *mainFont UI_APPEARANCE_SELECTOR;
 
+/// The main text highlighted color for the cell.
+@property (nonatomic) UIColor *mainHighlightedColor UI_APPEARANCE_SELECTOR;
+
 /// The secondary or detail text color for the cell.
 @property (nonatomic) UIColor *secondaryColor UI_APPEARANCE_SELECTOR;
 
 /// The secondary or detail text font for the cell.
 @property (nonatomic) UIFont *secondaryFont UI_APPEARANCE_SELECTOR;
+
+/// The secondary or detail text Highlighted color for the cell.
+@property (nonatomic) UIColor *secondaryHighlightedColor UI_APPEARANCE_SELECTOR;
 
 /// The color for the selected state of the cell.
 @property (nonatomic) UIColor *selectedColor UI_APPEARANCE_SELECTOR;

--- a/Bohr/BOTableViewCell.m
+++ b/Bohr/BOTableViewCell.m
@@ -29,8 +29,6 @@
 		self.clipsToBounds = YES;
 		self.textLabel.numberOfLines = 0;
 		self.textLabel.text = title;
-		self.textLabel.highlightedTextColor = [UIColor whiteColor];
-		self.detailTextLabel.highlightedTextColor = [UIColor whiteColor];
 		self.key = key;
 		self.setting = [BOSetting settingWithKey:self.key];
 	}
@@ -89,9 +87,11 @@
 	self.tintColor = self.secondaryColor;
 	
 	self.textLabel.textColor = self.mainColor;
+    self.textLabel.highlightedTextColor = self.mainHighlightedColor;
 	self.textLabel.font = self.mainFont;
 	
 	self.detailTextLabel.textColor = self.secondaryColor;
+    self.detailTextLabel.highlightedTextColor = self.secondaryHighlightedColor;
 	self.detailTextLabel.font = self.secondaryFont;
 	
 	self.selectedBackgroundView = [UIView new];


### PR DESCRIPTION
The highlighted color of the cell's labels are currently set to white by default.

The change is not to hardcode any value and to allow setting the color via appearance proxy.
