### PR TITLE
Defaults persistence storage abstraction

### DIFF
--- a/Bohr/BOSetting.h
+++ b/Bohr/BOSetting.h
@@ -16,6 +16,9 @@
 /// The NSUserDefaults value assigned for the key defined on the cell.
 @property (nonatomic, assign) id value;
 
+/// Can be called as many times as desired but the new value will only be applied if the current value is nil
+- (void)setDefaultValue:(id)value;
+
 /// Instantiates a new BOSetting object with a key.
 + (instancetype)settingWithKey:(NSString *)key;
 

--- a/Bohr/BOSetting.m
+++ b/Bohr/BOSetting.m
@@ -40,6 +40,12 @@
 	}
 }
 
+- (void)setDefaultValue:(id)value {
+    if (!self.value) {
+        self.value = value;
+    }
+}
+
 - (void)setValueDidChangeBlock:(void (^)(void))valueDidChangeBlock {
 	_valueDidChangeBlock = valueDidChangeBlock;
 	if (valueDidChangeBlock) valueDidChangeBlock();

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Here's an example of a really simple setup included in the demo project. Please 
 }
 ```
 
+You can also set default values during boostrapping of your app :
+```obj-c
+[[BOSetting settingWithKey:@"fontfamily"] setDefaultValue:@"verdana"];
+    [[BOSetting settingWithKey:@"fontsize"] setDefaultValue:@(16)];
+```
+These values will only be applied if the current value of these settings are nil, so you can call these methods at every launch without prior-checks.
+
+
 #### Built-in BOTableViewCell's
 
 There's a bunch of built-in `BOTableViewCell` subclasses ready to be used:


### PR DESCRIPTION
Settings always need default values so that :
- the first time the user goes into the Settings section, the default values are selected
- the setting values might be needed prior to user going in the Settings section of the app

The suggestion is to add this simple method in the Setting model class that will serve just that : easily specify default values for when no values have been set yet.

Usage example:

```
+ (void)applyDefaultValues
{
    [[BOSetting settingWithKey:@"fontfamily"] setDefaultValue:@"verdana"];
    [[BOSetting settingWithKey:@"fontsize"] setDefaultValue:@(16)];
}
```

This method would be called in the app delegate during app launch so that all ViewControllers already have valid values for the settings to start with.
