### PR TITLE
ChoiceTableViewCell : allow specific setting values so the option's indexes aren't used

### DIFF
--- a/Bohr/BOChoiceTableViewCell.h
+++ b/Bohr/BOChoiceTableViewCell.h
@@ -11,7 +11,11 @@
 @interface BOChoiceTableViewCell : BOTableViewCell
 
 /// An array defining all the options available for the cell.
-@property (nonatomic) NSArray *options;
+@property (nonatomic) NSArray<NSString *> *options;
+
+/// An optionnal array containing integer values of the options
+/// Size of array must be the same as size of options array
+@property (nonatomic) NSArray<NSNumber *> *optionValues;
 
 /// An array defining all the footer titles for each option assigned to the cell.
 @property (nonatomic) NSArray *footerTitles;

--- a/Bohr/BOChoiceTableViewCell.m
+++ b/Bohr/BOChoiceTableViewCell.m
@@ -17,7 +17,7 @@
 }
 
 - (NSString *)footerTitle {
-	NSInteger currentOption = [self.setting.value integerValue];
+	NSInteger currentOption = [self indexFromCurrentValue:[self.setting.value integerValue]];
 	
 	if (currentOption < self.footerTitles.count) {
 		return self.footerTitles[currentOption];
@@ -28,10 +28,10 @@
 
 - (void)wasSelectedFromViewController:(BOTableViewController *)viewController {
 	if (self.accessoryType != UITableViewCellAccessoryDisclosureIndicator) {
-		NSInteger currentOption = [self.setting.value integerValue];
+		NSInteger currentOption = [self indexFromCurrentValue:[self.setting.value integerValue]];
 		
 		if (currentOption < self.options.count-1) {
-			self.setting.value = @(currentOption+1);
+            self.setting.value = @([self valueForIndex:currentOption+1]);
 		} else {
 			self.setting.value = @0;
 		}
@@ -39,7 +39,24 @@
 }
 
 - (void)settingValueDidChange {
-	self.detailTextLabel.text = self.options[[self.setting.value integerValue]];
+    self.detailTextLabel.text = self.options[[self indexFromCurrentValue:[self.setting.value integerValue]]];
+}
+
+- (NSInteger)valueForIndex:(NSInteger)index {
+    if (self.optionValues) {
+        return [self.optionValues[index] integerValue];
+    } else {
+        return index;
+    }
+}
+
+- (NSInteger)indexFromCurrentValue:(NSInteger)value {
+    NSInteger index = value;
+    if (self.optionValues) {
+        index = [self.optionValues indexOfObject:@(value)];
+    }
+    
+    return index;
 }
 
 @end


### PR DESCRIPTION
Same concept as we had for the OptionTableViewCell - this allows specifying the setting value for each choice. Extremely useful when paired up with a separate destinationViewController as well.

Thanks again for making this open source, it's working out very well for me !

Also, would it be possible to tag a release after this PR is merged ?
